### PR TITLE
feat: support scrolling a container for preview screenshots (scrollSelector)

### DIFF
--- a/scripts/generate-previews.mjs
+++ b/scripts/generate-previews.mjs
@@ -166,8 +166,7 @@ const ensureDir = async (dir) => {
   await mkdir(dir, { recursive: true });
 };
 
-const captureTarget = async (browser, target, baseUrl) => {
-  const page = await browser.newPage();
+const configurePage = async (page, target) => {
   const viewport = target.viewport ?? { width: 1440, height: 900 };
   await page.setViewport({
     width: viewport.width,
@@ -188,18 +187,12 @@ const captureTarget = async (browser, target, baseUrl) => {
   if (Array.isArray(target.mediaFeatures) && target.mediaFeatures.length) {
     await page.emulateMediaFeatures(target.mediaFeatures);
   }
+};
 
-  const targetUrl = target.url
-    ? new URL(target.url, baseUrl)
-    : new URL(target.path ?? '/', baseUrl);
+const resolveTargetUrl = (target, baseUrl) =>
+  target.url ? new URL(target.url, baseUrl) : new URL(target.path ?? '/', baseUrl);
 
-  await page.goto(targetUrl.toString(), {
-    waitUntil: target.waitUntil ?? 'networkidle0',
-    timeout: target.timeout ?? 90_000,
-  });
-
-  await applyScrollTarget(page, target, delay);
-
+const waitAfterScroll = async (page, target) => {
   if (target.waitForSelector) {
     await page.waitForSelector(target.waitForSelector, {
       timeout: target.waitForSelectorTimeout ?? 30_000,
@@ -209,35 +202,56 @@ const captureTarget = async (browser, target, baseUrl) => {
   if (target.waitAfter) {
     await delay(target.waitAfter);
   }
+};
+
+const screenshotBySelector = async (page, selector, outputPath) => {
+  const rect = await page.$eval(selector, (element) => {
+    const { x, y, width, height } = element.getBoundingClientRect();
+    return { x, y, width, height };
+  });
+
+  if (!rect || !rect.width || !rect.height) {
+    throw new Error(`Selector "${selector}" did not return a measurable element.`);
+  }
+
+  await page.screenshot({
+    path: outputPath,
+    clip: {
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    },
+  });
+};
+
+const captureScreenshot = async (page, target, outputPath) => {
+  if (target.selector) {
+    await screenshotBySelector(page, target.selector, outputPath);
+    return;
+  }
+
+  await page.screenshot({
+    path: outputPath,
+    fullPage: target.fullPage ?? false,
+  });
+};
+
+const captureTarget = async (browser, target, baseUrl) => {
+  const page = await browser.newPage();
+  await configurePage(page, target);
+  const targetUrl = resolveTargetUrl(target, baseUrl);
+  await page.goto(targetUrl.toString(), {
+    waitUntil: target.waitUntil ?? 'networkidle0',
+    timeout: target.timeout ?? 90_000,
+  });
+
+  await applyScrollTarget(page, target, delay);
+  await waitAfterScroll(page, target);
 
   await ensureDir(assetsDir);
   const outputPath = path.join(assetsDir, target.name);
-
-  if (target.selector) {
-    const rect = await page.$eval(target.selector, (element) => {
-      const { x, y, width, height } = element.getBoundingClientRect();
-      return { x, y, width, height };
-    });
-
-    if (!rect || !rect.width || !rect.height) {
-      throw new Error(`Selector "${target.selector}" did not return a measurable element.`);
-    }
-
-    await page.screenshot({
-      path: outputPath,
-      clip: {
-        x: rect.x,
-        y: rect.y,
-        width: rect.width,
-        height: rect.height,
-      },
-    });
-  } else {
-    await page.screenshot({
-      path: outputPath,
-      fullPage: target.fullPage ?? false,
-    });
-  }
+  await captureScreenshot(page, target, outputPath);
 
   await page.close();
   console.log(`📸  Captured ${target.name}`);

--- a/scripts/generate-previews.mjs
+++ b/scripts/generate-previews.mjs
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'node:url';
 
 import puppeteer from 'puppeteer';
 
+import { applyScrollTarget } from './preview-scroll.mjs';
+
 const delay = (ms = 0) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -196,24 +198,7 @@ const captureTarget = async (browser, target, baseUrl) => {
     timeout: target.timeout ?? 90_000,
   });
 
-  if (typeof target.scrollPercent === 'number') {
-    await page.evaluate((pct) => {
-      const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
-      window.scrollTo(0, maxScroll * (pct / 100));
-    }, target.scrollPercent);
-
-    if (target.scrollWait ?? 0) {
-      await delay(target.scrollWait);
-    }
-  } else if (typeof target.scrollTo === 'number') {
-    await page.evaluate((scrollTop) => {
-      window.scrollTo(0, scrollTop);
-    }, target.scrollTo);
-
-    if (target.scrollWait ?? 0) {
-      await delay(target.scrollWait);
-    }
-  }
+  await applyScrollTarget(page, target, delay);
 
   if (target.waitForSelector) {
     await page.waitForSelector(target.waitForSelector, {

--- a/scripts/preview-scroll.mjs
+++ b/scripts/preview-scroll.mjs
@@ -1,0 +1,49 @@
+export const applyScrollTarget = async (page, target, delay = async () => {}) => {
+  const scrollWait = target.scrollWait ?? 0;
+
+  if (typeof target.scrollPercent === 'number') {
+    if (target.scrollSelector) {
+      await page.evaluate((selector, pct) => {
+        const container = document.querySelector(selector);
+        if (!container) {
+          throw new Error(`Scroll container not found for selector: ${selector}`);
+        }
+
+        const maxScroll = container.scrollHeight - container.clientHeight;
+        container.scrollTo(0, maxScroll * (pct / 100));
+      }, target.scrollSelector, target.scrollPercent);
+    } else {
+      await page.evaluate((pct) => {
+        const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+        window.scrollTo(0, maxScroll * (pct / 100));
+      }, target.scrollPercent);
+    }
+
+    if (scrollWait) {
+      await delay(scrollWait);
+    }
+
+    return;
+  }
+
+  if (typeof target.scrollTo === 'number') {
+    if (target.scrollSelector) {
+      await page.evaluate((selector, scrollTop) => {
+        const container = document.querySelector(selector);
+        if (!container) {
+          throw new Error(`Scroll container not found for selector: ${selector}`);
+        }
+
+        container.scrollTo(0, scrollTop);
+      }, target.scrollSelector, target.scrollTo);
+    } else {
+      await page.evaluate((scrollTop) => {
+        window.scrollTo(0, scrollTop);
+      }, target.scrollTo);
+    }
+
+    if (scrollWait) {
+      await delay(scrollWait);
+    }
+  }
+};

--- a/scripts/preview-scroll.test.mjs
+++ b/scripts/preview-scroll.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { applyScrollTarget } from './preview-scroll.mjs';
+
+const createMockPage = () => {
+  const calls = [];
+  return {
+    calls,
+    async evaluate(callback, ...args) {
+      calls.push({ callback: callback.toString(), args });
+    },
+  };
+};
+
+describe('applyScrollTarget', () => {
+  it('scrolls a selector when scrollPercent and scrollSelector are set', async () => {
+    const page = createMockPage();
+
+    await applyScrollTarget(page, {
+      scrollPercent: 50,
+      scrollSelector: 'main',
+    });
+
+    assert.equal(page.calls.length, 1);
+    assert.match(page.calls[0].callback, /document\.querySelector/);
+    assert.deepEqual(page.calls[0].args, ['main', 50]);
+  });
+});

--- a/scripts/preview-targets.json
+++ b/scripts/preview-targets.json
@@ -2,35 +2,54 @@
   {
     "name": "desktop-1.png",
     "path": "/",
-    "viewport": { "width": 1440, "height": 900 },
+    "viewport": {
+      "width": 1440,
+      "height": 900
+    },
     "scrollTo": 0,
-    "waitAfter": 2400
+    "waitAfter": 2400,
+    "scrollSelector": "main"
   },
   {
     "name": "desktop-3.png",
     "path": "/",
-    "viewport": { "width": 1440, "height": 900 },
+    "viewport": {
+      "width": 1440,
+      "height": 900
+    },
     "scrollPercent": 50,
-    "waitAfter": 1200
+    "waitAfter": 1200,
+    "scrollSelector": "main"
   },
   {
     "name": "desktop-4.png",
     "path": "/",
-    "viewport": { "width": 1440, "height": 900 },
+    "viewport": {
+      "width": 1440,
+      "height": 900
+    },
     "scrollPercent": 100,
-    "waitAfter": 1200
+    "waitAfter": 1200,
+    "scrollSelector": "main"
   },
   {
     "name": "desktop-2.png",
     "path": "/repos",
-    "viewport": { "width": 1440, "height": 900 },
+    "viewport": {
+      "width": 1440,
+      "height": 900
+    },
     "scrollTo": 1100,
-    "waitAfter": 2400
+    "waitAfter": 2400,
+    "scrollSelector": "main"
   },
   {
     "name": "mobile-1.png",
     "path": "/",
-    "viewport": { "width": 430, "height": 932 },
+    "viewport": {
+      "width": 430,
+      "height": 932
+    },
     "deviceScaleFactor": 3,
     "scrollTo": 0,
     "waitAfter": 2400
@@ -38,7 +57,10 @@
   {
     "name": "mobile-2.png",
     "path": "/",
-    "viewport": { "width": 430, "height": 932 },
+    "viewport": {
+      "width": 430,
+      "height": 932
+    },
     "deviceScaleFactor": 3,
     "scrollTo": 600,
     "waitAfter": 600
@@ -46,7 +68,10 @@
   {
     "name": "mobile-3.png",
     "path": "/repos",
-    "viewport": { "width": 430, "height": 932 },
+    "viewport": {
+      "width": 430,
+      "height": 932
+    },
     "deviceScaleFactor": 3,
     "scrollTo": 1200,
     "waitAfter": 800
@@ -54,7 +79,10 @@
   {
     "name": "mobile-4.png",
     "path": "/",
-    "viewport": { "width": 430, "height": 932 },
+    "viewport": {
+      "width": 430,
+      "height": 932
+    },
     "deviceScaleFactor": 3,
     "scrollPercent": 70,
     "waitAfter": 800


### PR DESCRIPTION
### Motivation
- Desktop preview captures (`assets/desktop-1.png`, `assets/desktop-3.png`, `assets/desktop-4.png`) were identical because the script only scrolled `window` while the visible content scrolls inside a container, so screenshots did not reflect different scroll positions.
- Introduce a way to target and scroll a specific container element so automated previews reflect the real app layout.

### Description
- Extracted scrolling logic into a new utility `scripts/preview-scroll.mjs` that supports `scrollPercent` and `scrollTo` for both `window` and a provided `scrollSelector` container.
- Updated `scripts/generate-previews.mjs` to import and call `applyScrollTarget` instead of directly calling `window.scrollTo`.
- Added `scrollSelector: "main"` to desktop preview targets in `scripts/preview-targets.json` so desktop screenshots scroll the actual `main` container.
- Added unit test `scripts/preview-scroll.test.mjs` that verifies selector-based scroll evaluation is invoked when `scrollSelector` is provided.

### Testing
- Ran `node --test scripts/preview-scroll.test.mjs` and the new test passed successfully.
- Ran `yarn lint` and `yarn check-type` and both completed without errors.
- Ran the full test suite with `yarn test` and all tests passed (`102` tests across `30` files passed).
- Attempted to regenerate screenshots with `node ./scripts/generate-previews.mjs -t desktop-1.png ...` but the local `yarn start` failed because a production build was not present, and `yarn build` failed in this environment due to inability to fetch the Google Font `Noto Sans KR`, so preview image generation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bacc2fb8d08322836bd33307d67773)