### PR TITLE
ci: skip workflow runs on bot PRs

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build-and-capture:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
     env:
       TZ: Asia/Seoul


### PR DESCRIPTION
Adds `if` condition to all jobs to skip execution when triggered by dependency bots (dependabot, renovate, etc.), reducing unnecessary Actions minutes usage.